### PR TITLE
Increase augur incursion limit

### DIFF
--- a/bin/augurExport.sh
+++ b/bin/augurExport.sh
@@ -11,6 +11,8 @@ metadata=$6
 locations=$7
 configjson=$8
 
+export AUGUR_RECURSION_LIMIT=10000
+
 # This process collects the relavant information and exports in json format for
 # direct visualization using Auspice: 
 # https://docs.nextstrain.org/projects/augur/en/stable/usage/cli/export.html


### PR DESCRIPTION
Just a small addition to ensure that augur successfully builds the json files for the largest clades.  More details here: [Augur Recursion Limit](https://discussion.nextstrain.org/t/augur-recursion-limit/201) and here: [Recursion Error](https://github.com/nextstrain/augur/issues/328)