### PR TITLE
Allocate number of cpus to processes

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -106,6 +106,7 @@ process cladematrix {
 
 process growtrees {
     errorStrategy 'ignore'
+    cpus 4
     tag "$clade"
     publishDir "$publishDir/trees/", mode: 'copy', pattern: '*_MP.nwk'
     input:

--- a/main.nf
+++ b/main.nf
@@ -79,7 +79,9 @@ process cladeMetadata{
 }
 
 process cladesnps {
-    errorStrategy 'ignore'
+    errorStrategy 'retry'
+    maxRetries 2
+    maxForks 3
     tag "$clade"
     publishDir "$publishDir/snp-fasta/", mode: 'copy', pattern: '*_snp-only.fas'
     input:
@@ -93,6 +95,7 @@ process cladesnps {
 
 process cladematrix {
     errorStrategy 'ignore'
+    maxForks 3
     tag "$clade"
     publishDir "$publishDir/snp-matrix/", mode: 'copy', pattern: '*.csv'
     input:


### PR DESCRIPTION
When run `-with-docker` the pipeline was considerably slower.  This issue: <https://github.com/nextflow-io/nextflow/discussions/2699> shows that by default `docker run` only allocates a single core for each process.  This is fine in most cases as the parallelization means that multiple processes can run concurrently.  However, for the tree construction with mega additional cores are required, so this is now defined as a specific directive for the `growtrees` process.  In addition, I have limited the maximum number of forks which can be started for some processes, enabling the longer running `growtrees` processes to start earlier and therefore reduce the total run time of the pipeline