### PR TITLE
Docker fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
     wget \
     curl \
     unzip \
+    gawk \
     gcc \
     git \
     make \

--- a/main.nf
+++ b/main.nf
@@ -81,7 +81,8 @@ process cladeMetadata{
 process cladesnps {
     errorStrategy 'retry'
     maxRetries 2
-    maxForks 3
+    maxForks 5
+    cpus 2
     tag "$clade"
     publishDir "$publishDir/snp-fasta/", mode: 'copy', pattern: '*_snp-only.fas'
     input:


### PR DESCRIPTION
It turns out that the ubuntu base image which docker is built has uses `mawk` when `awk` is called.  Turns out that `mawk` functionality  differs from what we expect from `awk`.  To fix this GNU awk `gawk` needs to be specifically installed when the image is built.

Additional change has been made to the assignment or resources to processes in the pipeline