### PR TITLE
Post process snp matrix

### DIFF
--- a/bin/addsub.sh
+++ b/bin/addsub.sh
@@ -9,20 +9,22 @@ set -eo pipefail
 file=$1
 while IFS= read -r line;
 do
+    echo $line
     sample=$(echo "$line" | awk -F, '/[A-Z]*-*[0-9]{2,2}-[0-9]{4,5}-[0-9]{2,2}*/ {print $1}');
     if [[ -z $sample ]];
         then subno=$(echo "$line" | awk -F, '{print $1}');
-        else
-            IFS=-, read -r -a array <<< $sample
-            if [[ ${array[0]} = [A-Z]* ]]; 
-                then fivedig=$(echo "${array[2]}" | sed 's/\b[0-9]\{4\}\b/0&/1')
-                    year=$(echo ${array[3]} | sed 's/^\(.\{2\}\).*$/\1/')
-                    subno=$(echo AF-${array[1]}-$fivedig-$year); 
-                else fivedig=$(echo "${array[1]}" | sed 's/\b[0-9]\{4\}\b/0&/1')
-                    year=$(echo ${array[2]} | sed 's/^\(.\{2\}\).*$/\1/')
-                    subno=$(echo AF-${array[0]}-$fivedig-$year);
-            fi
+    else
+        IFS=-, read -r -a array <<< $sample
+        if [[ ${array[0]} = [A-Z]* ]]; 
+            then fivedig=$(echo "${array[2]}" | sed 's/\b[0-9]\{4\}\b/0&/1')
+                year=$(echo ${array[3]} | sed 's/^\(.\{2\}\).*$/\1/')
+                subno=$(echo AF-${array[1]}-$fivedig-$year); 
+            else fivedig=$(echo "${array[1]}" | sed 's/\b[0-9]\{4\}\b/0&/1')
+                year=$(echo ${array[2]} | sed 's/^\(.\{2\}\).*$/\1/')
+                subno=$(echo AF-${array[0]}-$fivedig-$year);
         fi
+    fi
+    echo $sunbo
     echo -e "$subno,$line" >> withsub.csv
     
 done <"$file"

--- a/bin/addsub.sh
+++ b/bin/addsub.sh
@@ -1,30 +1,15 @@
 #!/bin/bash
 
+# Bash cript to add the submission number the first column of the csv file.
+
 set -eo pipefail
 
-# Bash script to determine submission number from a sample number using regex 
-# (*-nn-(n)nnnn-nn). The submission number is then added as the first column of
-# the csv file.
-
 file=$1
-while IFS= read -r line;
+echo -e "Submission,$(head -n 1 $file)" >> withsub.csv
+sed 1d $file | while IFS= read -r line;
 do
-    echo $line
-    sample=$(echo "$line" | awk -F, '/[A-Z]*-*[0-9]{2,2}-[0-9]{4,5}-[0-9]{2,2}*/ {print $1}');
-    if [[ -z $sample ]];
-        then subno=$(echo "$line" | awk -F, '{print $1}');
-    else
-        IFS=-, read -r -a array <<< $sample
-        if [[ ${array[0]} = [A-Z]* ]]; 
-            then fivedig=$(echo "${array[2]}" | sed 's/\b[0-9]\{4\}\b/0&/1')
-                year=$(echo ${array[3]} | sed 's/^\(.\{2\}\).*$/\1/')
-                subno=$(echo AF-${array[1]}-$fivedig-$year); 
-            else fivedig=$(echo "${array[1]}" | sed 's/\b[0-9]\{4\}\b/0&/1')
-                year=$(echo ${array[2]} | sed 's/^\(.\{2\}\).*$/\1/')
-                subno=$(echo AF-${array[0]}-$fivedig-$year);
-        fi
-    fi
-    echo $sunbo
+    IFS="," read -ra line_array <<< $line
+    subno=$(bash extractSub.sh ${line_array[0]})
+    echo $subno
     echo -e "$subno,$line" >> withsub.csv
-    
-done <"$file"
+done

--- a/bin/addsub.sh
+++ b/bin/addsub.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Bash cript to add the submission number the first column of the csv file.
+# Bash script to add the submission number the first column of the csv file.
 
 set -eo pipefail
 

--- a/bin/buildmatrix.sh
+++ b/bin/buildmatrix.sh
@@ -3,10 +3,8 @@
 set -eo pipefail
 
 snponlyfasta=$1
-clade=$2
-today=$3
 
 # Runs snp-dists (https://github.com/tseemann/snp-dists) to generate distance 
 # matrix using output from snp-sites
 
-~/snp-dists/snp-dists -c $snponlyfasta > ${clade}_${today}_matrix.csv
+~/snp-dists/snp-dists -c $snponlyfasta > snp_matrix.csv

--- a/bin/extractSub.sh
+++ b/bin/extractSub.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -eo pipefail
+
+sample=$(echo "$1" | awk -F, '/[A-Z]*-*[0-9]{2,2}-[0-9]{4,5}-[0-9]{2,2}*/ {print $1}');
+if [[ -z $sample ]];
+    then subno=$1
+else
+    IFS=-, read -r -a array <<< $sample
+    if [[ ${array[0]} = [A-Z]* ]]; 
+        then fivedig=$(echo "${array[2]}" | sed 's/\b[0-9]\{4\}\b/0&/1')
+            year=$(echo ${array[3]} | sed 's/^\(.\{2\}\).*$/\1/')
+            subno=$(echo AF-${array[1]}-$fivedig-$year); 
+        else fivedig=$(echo "${array[1]}" | sed 's/\b[0-9]\{4\}\b/0&/1')
+            year=$(echo ${array[2]} | sed 's/^\(.\{2\}\).*$/\1/')
+            subno=$(echo AF-${array[0]}-$fivedig-$year);
+    fi
+fi
+echo $subno

--- a/bin/extractSub.sh
+++ b/bin/extractSub.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Extracts submission number from a sample number using regex (*-nn-(n)nnnn-nn). 
+
 set -eo pipefail
 
 sample=$(echo "$1" | awk -F, '/[A-Z]*-*[0-9]{2,2}-[0-9]{4,5}-[0-9]{2,2}*/ {print $1}');

--- a/bin/postprocessMatrix.sh
+++ b/bin/postprocessMatrix.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -eo pipefail
+
+file=$1
+IFS=","
+read -ra samples <<< $(head -n 1 $file)
+subno_array=()
+for sample in "${samples[@]}"
+    do  
+        subno=$(bash extractSub.sh $sample)
+        subno_array+=( "$subno" )
+    done
+headers=${subno_array[*]}
+echo "$headers" >> post_process_matrix.csv
+cat post_process_matrix.csv
+i=0
+sed 1d $file | while IFS= read -r line;
+do
+    i=$i+1
+    echo -e "${subno_array[$i]},$( echo $line | cut -d ',' -f1 --complement )" >> post_process_matrix.csv
+done

--- a/bin/postprocessMatrix.sh
+++ b/bin/postprocessMatrix.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
+# Converts sample names in the snp matrix to a submission number.
+
 set -eo pipefail
 
 file=$1
+clade=$2
+today=$3
+
 IFS=","
 read -ra samples <<< $(head -n 1 $file)
 subno_array=()
@@ -18,5 +23,5 @@ i=0
 sed 1d $file | while IFS= read -r line;
 do
     i=$i+1
-    echo -e "${subno_array[$i]},$( echo $line | cut -d ',' -f1 --complement )" >> post_process_matrix.csv
+    echo -e "${subno_array[$i]},$( echo $line | cut -d ',' -f1 --complement )" >> ${clade}_${today}_matrix.csv
 done

--- a/bin/postprocessMatrix.sh
+++ b/bin/postprocessMatrix.sh
@@ -18,7 +18,6 @@ for sample in "${samples[@]}"
     done
 headers=${subno_array[*]}
 echo "$headers" >> post_process_matrix.csv
-cat post_process_matrix.csv
 i=0
 sed 1d $snp_matrix | while IFS= read -r line;
 do

--- a/bin/postprocessMatrix.sh
+++ b/bin/postprocessMatrix.sh
@@ -17,7 +17,6 @@ for sample in "${samples[@]}"
         subno_array+=( "$subno" )
     done
 headers=${subno_array[*]}
-echo "$headers"
 echo "$headers" >> ${clade}_${today}_matrix.csv
 i=1
 IFS= 

--- a/bin/postprocessMatrix.sh
+++ b/bin/postprocessMatrix.sh
@@ -4,12 +4,12 @@
 
 set -eo pipefail
 
-file=$1
+snp_matrix=$1
 clade=$2
 today=$3
 
 IFS=","
-read -ra samples <<< $(head -n 1 $file)
+read -ra samples <<< $(head -n 1 $snp_matrix)
 subno_array=()
 for sample in "${samples[@]}"
     do  
@@ -20,7 +20,7 @@ headers=${subno_array[*]}
 echo "$headers" >> post_process_matrix.csv
 cat post_process_matrix.csv
 i=0
-sed 1d $file | while IFS= read -r line;
+sed 1d $snp_matrix | while IFS= read -r line;
 do
     i=$i+1
     echo -e "${subno_array[$i]},$( echo $line | cut -d ',' -f1 --complement )" >> ${clade}_${today}_matrix.csv

--- a/bin/postprocessMatrix.sh
+++ b/bin/postprocessMatrix.sh
@@ -17,10 +17,12 @@ for sample in "${samples[@]}"
         subno_array+=( "$subno" )
     done
 headers=${subno_array[*]}
-echo "$headers" >> post_process_matrix.csv
-i=0
-sed 1d $snp_matrix | while IFS= read -r line;
+echo "$headers"
+echo "$headers" >> ${clade}_${today}_matrix.csv
+i=1
+IFS= 
+sed 1d $snp_matrix | while read -r line;
 do
-    i=$i+1
     echo -e "${subno_array[$i]},$( echo $line | cut -d ',' -f1 --complement )" >> ${clade}_${today}_matrix.csv
+    i=$i+1
 done

--- a/main.nf
+++ b/main.nf
@@ -103,7 +103,8 @@ process cladematrix {
     output:
         tuple val(clade), path("${clade}_${params.today}_matrix.csv")
     """
-    buildmatrix.sh snp-only.fas $clade ${params.today}
+    buildmatrix.sh snp-only.fas 
+    postProcessMatrix.sh snp_matrix.csv $clade ${params.today}
     """
 }
 


### PR DESCRIPTION
This PR fixes the sample names in the snp matrix output so that they are instead submission numbers. This is needed for pairing with metadata.

* A new script, `extractSub.sh` is created which serves only to convert a sample name into a submission number, with code ripped from the original `addsub.sh` file. This is because this routine is now used twice.
* `addsub.sh` is adapted to utilise this new script.
*  A new script `postprocessMatrix.sh` processes the snp matricies to change row and column names into submission numbers using `extractSub.sh` - this reads sample names into an array (line 12), loops through the array extracting the submission number and appending to a new array. The new snp_matrix header is written on line 20. Subsequent lines are written to the snp matrix in a loop, (line 26).
* The running of the `postprocessMatrix.sh` script is appended to the `cladematrix` nf process: `build_matrix.sh` outputs an intermediary file `snp_matrix.csv` which is read in by `postprocessMatrix.sh`.

I am not sure how NF deals with staging scripts, I'm not sure if the `extractSub.sh` script will be staged correctly, since it isn't explicitly called within the NF command. I.e. I'm concerned it won't be present in the required work folder. 
 

