### PR TITLE
Wgs meta 2 sqlite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .nextflow/
 .nextflow.log*
+work/

--- a/bin/metadata2sqlite.py
+++ b/bin/metadata2sqlite.py
@@ -10,14 +10,18 @@ import pandas as pd
     Writes one database file, 'viewbovis.db', to the working directory.
 """
 
-def convert_to_sqlite(metadata_csv_path, latlon_csv_path):
+def convert_to_sqlite(wgs_metadata_path, metadata_path, latlon_path):
     conn = sqlite3.connect("viewbovis.db")
+    # write filtered wgs metadata to sqlite db
+    df_wgs_metadata = pd.read_csv(wgs_metadata_path, index_col="Submission", 
+                                  dtype=str)
+    df_wgs_metadata.to_sql("metadata", con=conn, if_exists="replace")
     # write metadata to sqlite db
-    df_metadata = pd.read_csv(metadata_csv_path, index_col="Submission", 
+    df_metadata = pd.read_csv(metadata_path, index_col="Submission", 
                               dtype=str)
     df_metadata.to_sql("metadata", con=conn, if_exists="replace")
     # write lat-lon data to sqlite db
-    df_locations = pd.read_csv(latlon_csv_path, index_col="CPH", 
+    df_locations = pd.read_csv(latlon_path, index_col="CPH", 
                             dtype={"CPH": str, 
                                    "Lat": float,
                                    "Long": float})
@@ -25,7 +29,9 @@ def convert_to_sqlite(metadata_csv_path, latlon_csv_path):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('metadata_csv_path', help='path to metadata.csv')
-    parser.add_argument('latlon_csv_path', help='path to latlon.csv')
+    parser.add_argument('wgs_metadata_path', 
+                        help='path to filteredWgsMetadata.csv')
+    parser.add_argument('metadata_path', help='path to metadata.csv')
+    parser.add_argument('latlon_path', help='path to latlon.csv')
     args = parser.parse_args()
     convert_to_sqlite(**vars(args))


### PR DESCRIPTION
This PR is an alternative to https://github.com/APHA-CSU/btb-forestry/pull/18#issue-1605271741. 

Instead of changing the sample names in the SNP matrix to submission numbers, the WGS metadata is included in the sqlite db. This way when looking up related samples in snp matricies the submission number can be extracted from the WGS metadata table before searching for movement metadata.

A new channel `filteredWgsMeta` is generated which collects the outputs from filterSamples. 

This channel is used as an additional input into `metadata2sqlite` process. 

