### PR TITLE
add PreciseLocation to geo_resolutions

### DIFF
--- a/accessory/auspice_config.json
+++ b/accessory/auspice_config.json
@@ -46,7 +46,7 @@
     }
   ],
   "geo_resolutions": [
-    "CPH",
+    "PreciseLocation",
     "County"
   ],
   "display_defaults": {


### PR DESCRIPTION
this PR is just a small bug fix so that 'PreciseLocation' can be used instead of 'CPH'