### PR TITLE
Consistent labels

### DIFF
--- a/accessory/auspice_config.json
+++ b/accessory/auspice_config.json
@@ -46,9 +46,13 @@
     }
   ],
   "geo_resolutions": [
-    "PreciseLocation",
+    {
+      "key": "PreciseLocation",
+      "title": "Precise Location"
+    },
     "County"
   ],
+
   "display_defaults": {
     "map_triplicate": true,
     "color_by": "Host",

--- a/accessory/auspice_config.json
+++ b/accessory/auspice_config.json
@@ -16,7 +16,7 @@
     },
     {
       "key": "Host",
-      "title": "Host",
+      "title": "Species",
       "type": "categorical"
     },
     {

--- a/accessory/auspice_config.json
+++ b/accessory/auspice_config.json
@@ -57,7 +57,7 @@
     "map_triplicate": true,
     "color_by": "Host",
     "geo_resolution": "PreciseLocation",
-    "branch_label": "snps",
+    "branch_label": "SNP Distance",
     "panels": ["tree", "map"]
   },
   "filters": [

--- a/accessory/auspice_config.json
+++ b/accessory/auspice_config.json
@@ -26,7 +26,7 @@
     },
     {
       "key": "CPH_Type",
-      "title": "CPH Type",
+      "title": "Precise Location Type",
       "type": "categorical"
     },
     {

--- a/accessory/auspice_config.json
+++ b/accessory/auspice_config.json
@@ -31,7 +31,7 @@
     },
     {
       "key": "OutsideHomeRange",
-      "title": "Outside Home Range",
+      "title": "Out of Home Range",
       "type": "categorical"
     },
     {

--- a/bin/augurExport.sh
+++ b/bin/augurExport.sh
@@ -29,4 +29,4 @@ augur export v2 -t $nwktree \
             --colors $colors \
             --output ${clade}.json
 
-sed -i 's/"snps": 0//g' ${clade}.json
+sed -i 's/"SNP Distance": 0//g' ${clade}.json


### PR DESCRIPTION
These updates work in conjunction with changes in other Nextstrain components [Augur PR#4](https://github.com/APHA-CSU/augur/pull/4) to provide naming which is consistent with the rest of the ViewBovis app

- 'Outside Home Range' -> 'Out of Home Range
- 'CPH Type' -> 'Precise Location Type'
- 'Host' -> 'Species'
- 'PreciseLocation' -> 'Precise Location' for geographic resolution
- 'snps' -> 'SNP Distance'