### PR TITLE
Name latest upload prod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ work/
 bin/__pycache__/
 tests/__pycache__/
 .vscode/
+metadata.json

--- a/bin/forestMeta.sh
+++ b/bin/forestMeta.sh
@@ -3,6 +3,7 @@
 set -eo pipefail
 
 TODAY=$1
+COMMIT=$2
 
 # write metadata.json with today's date
-jq -n --arg jq_date $TODAY --arg jq_commit $(git rev-parse HEAD) '{"today": $jq_date, "git_commit": $jq_commit}' > metadata.json
+jq -n --arg jq_date $TODAY --arg jq_commit $COMMIT '{"today": $jq_date, "git_commit": $jq_commit}' > metadata.json

--- a/bin/forestMeta.sh
+++ b/bin/forestMeta.sh
@@ -3,6 +3,7 @@
 set -eo pipefail
 
 TODAY=$1
+GIT_COMMIT=$2
 
 # write metadata.json with today's date
-jq -n --arg jq_date $TODAY --arg jq_commit $(git rev-parse HEAD) '{"today": $jq_date, "git_commit": $jq_commit}' > metadata.json
+jq -n --arg jq_date $TODAY --arg jq_commit $GIT_COMMIT '{"today": $jq_date, "git_commit": $jq_commit}' > metadata.json

--- a/bin/forestMeta.sh
+++ b/bin/forestMeta.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -eo pipefail
+
+TODAY=$1
+
+# write metadata.json with today's date
+jq -n --arg jq_date $TODAY --arg jq_commit $(git rev-parse HEAD) '{"today": $jq_date, "git_commit": $jq_commit}' > metadata.json

--- a/bin/forestMeta.sh
+++ b/bin/forestMeta.sh
@@ -3,7 +3,6 @@
 set -eo pipefail
 
 TODAY=$1
-COMMIT=$2
 
 # write metadata.json with today's date
-jq -n --arg jq_date $TODAY --arg jq_commit $COMMIT '{"today": $jq_date, "git_commit": $jq_commit}' > metadata.json
+jq -n --arg jq_date $TODAY --arg jq_commit $(git rev-parse HEAD) '{"today": $jq_date, "git_commit": $jq_commit}' > metadata.json

--- a/bin/s3prod.sh
+++ b/bin/s3prod.sh
@@ -19,7 +19,5 @@ TODAY=$2
     }
 }
 
-echo $TODAY
-
 # write metadata.json with today's date
 jq -n --arg jq_date $TODAY '{"today": $jq_date}' > metadata.json

--- a/bin/s3prod.sh
+++ b/bin/s3prod.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e
+
+set -eo pipefail
 
 S3_PATH=$1
 TODAY=$2
@@ -18,5 +19,7 @@ TODAY=$2
     }
 }
 
+echo $TODAY
+
 # write metadata.json with today's date
-echo '{"today": ${TODAY}}' | jq . > metadata.json
+jq -n --arg jq_date $TODAY '{"today": $jq_date}' > metadata.json

--- a/bin/s3prod.sh
+++ b/bin/s3prod.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+S3_PATH=$1
+TODAY=$2
+
+# backup production files
+# skip the backup stage if the prod/ folder is missing in $S3_PATH
+{
+    # extract date of current production files from $S3_PATH
+    aws s3 cp ${S3_PATH}/btb-forest_prod/Metadata/metadata.json metadata_prod.json &&
+    {
+	backup_date=($(sed -e 's/^"//' -e 's/"$//' <<< $(jq '.today' metadata_prod.json)))
+	backup_date=${backup_date[0]}
+
+	# backup current production files in $S3_PATH
+	aws s3 mv --recursive ${S3_PATH}/btb-forest_prod/ ${S3_PATH}/btb-forest_${backup_date}/ --acl bucket-owner-full-control
+    }
+}
+
+# write metadata.json with today's date
+echo '{"today": ${TODAY}}' | jq . > metadata.json

--- a/bin/s3prod.sh
+++ b/bin/s3prod.sh
@@ -3,7 +3,6 @@
 set -eo pipefail
 
 S3_PATH=$1
-TODAY=$2
 
 # backup production files
 # skip the backup stage if the prod/ folder is missing in $S3_PATH
@@ -18,6 +17,3 @@ TODAY=$2
 	aws s3 mv --recursive ${S3_PATH}/btb-forest_prod/ ${S3_PATH}/btb-forest_${backup_date}/ --acl bucket-owner-full-control
     }
 }
-
-# write metadata.json with today's date
-jq -n --arg jq_date $TODAY '{"today": $jq_date}' > metadata.json

--- a/main.nf
+++ b/main.nf
@@ -200,6 +200,8 @@ process metadata2sqlite{
 
 //If running in production mode > backup the current production data
 process backupProdData {
+    output:
+        stdout 
     """
     s3prod.sh ${params.outdir}
     """
@@ -207,6 +209,8 @@ process backupProdData {
 
 process forestryMetdata{
     publishDir "$publishDir/Metadata/", mode: 'copy'
+    input:
+        val go    
     output:
         path('metadata.json')
     """
@@ -264,9 +268,10 @@ workflow {
 
     if( params.prod_run ){
         backupProdData()
+        forestryMetdata(backupProdData.out)
+    } else {
+        forestryMetdata(0)
     }
-
-    forestryMetdata()
 /*
     cleandata(inputCsv)
 

--- a/main.nf
+++ b/main.nf
@@ -198,16 +198,21 @@ process metadata2sqlite{
     """
 }
 
-//If running in production mode > backup the current production data
-process backupProdData {
+process forestryMetdata{
     publishDir "$publishDir/Metadata/", mode: 'copy'
     output:
         path('metadata.json')
     """
-    s3prod.sh ${params.outdir} ${params.today}       
+    forestMeta.sh ${params.today}
     """
 }
 
+//If running in production mode > backup the current production data
+process backupProdData {
+    """
+    s3prod.sh ${params.outdir}
+    """
+}
 
 workflow {
     // Concatenate all FinalOut csv files
@@ -257,10 +262,12 @@ workflow {
         .fromPath( params.userMP )
         .set {userMP}
 
+    forestryMetdata()
+
     if( params.prod_run ){
         backupProdData()
     }
-
+/*
     cleandata(inputCsv)
 
     sortmetadata(metadata, movements)
@@ -336,5 +343,5 @@ workflow {
     jsonExport(exportData)
 
     metadata2sqlite(filteredWgsMeta, metadata, movements, cphlocs, excluded.out)
-    
+*/    
 }

--- a/main.nf
+++ b/main.nf
@@ -267,7 +267,7 @@ workflow {
     if( params.prod_run ){
         backupProdData()
     }
-/*
+
     cleandata(inputCsv)
 
     sortmetadata(metadata, movements)
@@ -343,5 +343,5 @@ workflow {
     jsonExport(exportData)
 
     metadata2sqlite(filteredWgsMeta, metadata, movements, cphlocs, excluded.out)
-*/    
+    
 }

--- a/main.nf
+++ b/main.nf
@@ -258,7 +258,7 @@ workflow {
         .set {userMP}
 
     if( params.prod_run ){
-        backupProdData
+        backupProdData()
     }
 
     cleandata(inputCsv)
@@ -336,4 +336,5 @@ workflow {
     jsonExport(exportData)
 
     metadata2sqlite(filteredWgsMeta, metadata, movements, cphlocs, excluded.out)
+    
 }

--- a/main.nf
+++ b/main.nf
@@ -203,7 +203,7 @@ process forestryMetdata{
     output:
         path('metadata.json')
     """
-    forestMeta.sh ${params.today}
+    forestMeta.sh ${params.today} ${workflow.commitId}
     """
 }
 
@@ -267,7 +267,7 @@ workflow {
     if( params.prod_run ){
         backupProdData()
     }
-
+/*
     cleandata(inputCsv)
 
     sortmetadata(metadata, movements)
@@ -343,5 +343,5 @@ workflow {
     jsonExport(exportData)
 
     metadata2sqlite(filteredWgsMeta, metadata, movements, cphlocs, excluded.out)
-    
+*/    
 }

--- a/main.nf
+++ b/main.nf
@@ -10,7 +10,6 @@ else{
     publishDir = "$params.outdir/btb-forest_${params.today}/"
 }
 
-
 //Add submission number and ensure single (highest quality) entry for each submission
 process cleandata {
     publishDir "$publishDir", mode: 'copy', pattern: 'bTB_Allclean_*.csv'
@@ -214,7 +213,7 @@ process forestryMetdata{
     output:
         path('metadata.json')
     """
-    forestMeta.sh ${params.today} ${workflow.commitId}
+    forestMeta.sh ${params.today}
     """
 }
 
@@ -272,7 +271,7 @@ workflow {
     } else {
         forestryMetdata(0)
     }
-/*
+
     cleandata(inputCsv)
 
     sortmetadata(metadata, movements)
@@ -348,5 +347,4 @@ workflow {
     jsonExport(exportData)
 
     metadata2sqlite(filteredWgsMeta, metadata, movements, cphlocs, excluded.out)
-*/    
 }

--- a/main.nf
+++ b/main.nf
@@ -198,19 +198,19 @@ process metadata2sqlite{
     """
 }
 
+//If running in production mode > backup the current production data
+process backupProdData {
+    """
+    s3prod.sh ${params.outdir}
+    """
+}
+
 process forestryMetdata{
     publishDir "$publishDir/Metadata/", mode: 'copy'
     output:
         path('metadata.json')
     """
     forestMeta.sh ${params.today} ${workflow.commitId}
-    """
-}
-
-//If running in production mode > backup the current production data
-process backupProdData {
-    """
-    s3prod.sh ${params.outdir}
     """
 }
 
@@ -262,11 +262,11 @@ workflow {
         .fromPath( params.userMP )
         .set {userMP}
 
-    forestryMetdata()
-
     if( params.prod_run ){
         backupProdData()
     }
+
+    forestryMetdata()
 /*
     cleandata(inputCsv)
 

--- a/main.nf
+++ b/main.nf
@@ -213,7 +213,7 @@ process forestryMetdata{
     output:
         path('metadata.json')
     """
-    forestMeta.sh ${params.today}
+    forestMeta.sh ${params.today} ${workflow.commitId}
     """
 }
 
@@ -272,6 +272,7 @@ workflow {
         forestryMetdata(0)
     }
 
+/*
     cleandata(inputCsv)
 
     sortmetadata(metadata, movements)
@@ -347,4 +348,5 @@ workflow {
     jsonExport(exportData)
 
     metadata2sqlite(filteredWgsMeta, metadata, movements, cphlocs, excluded.out)
+    */
 }

--- a/main.nf
+++ b/main.nf
@@ -272,7 +272,6 @@ workflow {
         forestryMetdata(0)
     }
 
-/*
     cleandata(inputCsv)
 
     sortmetadata(metadata, movements)
@@ -348,5 +347,4 @@ workflow {
     jsonExport(exportData)
 
     metadata2sqlite(filteredWgsMeta, metadata, movements, cphlocs, excluded.out)
-    */
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,4 +1,0 @@
-{
-  "today": "14Aug23",
-  "git_commit": "430b64f14dbb500184bfa3b581f7f931fec20765"
-}

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,4 @@
+{
+  "today": "14Aug23",
+  "git_commit": "430b64f14dbb500184bfa3b581f7f931fec20765"
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -36,6 +36,7 @@ params.cladeinfo = "$projectDir/accessory/CladeInfo.csv"
 params.today = new Date().format('ddMMMYY')
 params.outdir = "$PWD"
 params.homedir = "$HOME"
+params.prod_run = false
 
 // Location of megacc analysis options (.mao) files 
 params.maxP200x = "$projectDir/accessory/infer_MP_nucleotide_200x.mao"


### PR DESCRIPTION
This PR deals with naming of production data uploaded to s3 at the end of a production run. 

It is a precursor to a proposed automation step written into the ViewBovis server which will pull files from `s3://s3-csu-003/v3-2/btb-forest_prod` every morning after it is booted up.

## changes
1. an additional parameter, `prod_run` is set to `false`, by default in `nextflow.config`. By setting this to `true` when calling the pipeline on the CLI, users are indicating that this run is for production purposes and the output data should then replace the current production data in s3.
2. `publishDir` is set to either `$params.outdir/btb-forest_prod/"` if in production mode, or else `publishDir = "$params.outdir/btb-forest_${params.today}/"` (lines 6-12 in `main.nf`).
3. An additional process `forestryMetdata` (lines 201-208) calls `forestMeta.sh` which produces a `metadata.json` file which looks like. This is published.:
```
  {
     "today": "14Aug23",
     "git_commit": "430b64f14dbb500184bfa3b581f7f931fec20765"
   }
```
This process is called first.
4. An additional process, `backupProdData`, is called straight after `forestryMeta`, **only if the run is production mode**. This process calls `s3prod.sh`, which i) pulls the `metadata.json` file from the current or most recent prod data (line 11); ii) extracts the date that this production run was run on (line12); iii) moves the production folder, `s3://s3-csu-003/v3-2/btb-forest_prod`, to a dated alternative, e.g. `s3://s3-csu-003/v3-2/btb-forest_14Aug23/` (line 17).

## new changes (21/08/2023)
The order of the processes is corrected where now the backup stage `backupProdData` occurs before writing the new `metadata.json` as this was causing an obvious issue where the brand new (current run) data was being "backed-up" thus also deleting the real back-up.

I have added a dependency for `forestMeta` on the `stdout` of `backupProdData` to ensure they run synchronously. 