### PR TITLE
Additional matrix output

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -10,6 +10,8 @@ else{
     publishDir = "$params.outdir/btb-forest_${params.today}/"
 }
 
+matrixCopy = "params.matrixdir/SNP_matrix_${params.today}/"
+
 //Add submission number and ensure single (highest quality) entry for each submission
 process cleandata {
     publishDir "$publishDir", mode: 'copy', pattern: 'bTB_Allclean_*.csv'

--- a/main.nf
+++ b/main.nf
@@ -122,6 +122,7 @@ process cladematrix {
     maxForks 2
     tag "$clade"
     publishDir "$publishDir/snp-matrix/", mode: 'copy', pattern: '*.csv'
+    publishDir "$matrixCopy/", mode: 'copy', pattern: '*.csv'
     input:
         tuple val(clade), path('snp-only.fas')
     output:

--- a/nextflow.config
+++ b/nextflow.config
@@ -37,6 +37,7 @@ params.today = new Date().format('ddMMMYY')
 params.outdir = "$PWD"
 params.homedir = "$HOME"
 params.prod_run = false
+params.matrixdir = "$PWD/matrixcopy"
 
 // Location of megacc analysis options (.mao) files 
 params.maxP200x = "$projectDir/accessory/infer_MP_nucleotide_200x.mao"


### PR DESCRIPTION
To enable Data Systems Group and Epidemiology colleagues to make use of the SNP matrices this PR adds the functionality to output the csv files to a different location which they have access to.  The exact location can be defined on the command line using the `--matrixdir` option to override the default in the config file.